### PR TITLE
Support undionly.kpxe from ipxe repo

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -251,6 +251,12 @@ function messageHandlerFactory(
             return 'monorail.intel.ipxe';
         }
 
+        // Some NICs use UNDI driver, it needs chainload ipxe's undionly.kpxe file to bootup
+        if (packetData.options.vendorClassIdentifier &&
+                packetData.options.vendorClassIdentifier.indexOf('UNDI') !== -1) {
+            return 'monorail-undionly.kpxe';
+        }
+
         if (packetData.options.vendorClassIdentifier) {
             if (packetData.options.archType === 7 || packetData.options.archType === 9) {
                 return 'monorail-efi64-snponly.efi';

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -257,25 +257,8 @@ function messageHandlerFactory(
             return 'monorail.intel.ipxe';
         }
 
-        /* Notes for UNDI
-         * 1) Some NICs support UNDI driver, it needs chainload ipxe's undionly.kpxe file to bootup
-         * otherwise it will hang using monorail.ipxe. NOTE: if 'UNDI' is in class identifier
-         * but cannot boot for some NICs, please use MAC address or other condition to
-         * judge if use monorail-undionly.kpxe or not
-         *
-         * 2) Some Notes from PXE spec about DHCP options:
-         * PXEClient:Arch:xxxxx:UNDI:yyyzzz used for  transactions between client and server.
-         * (These strings are case sensitive. This field must not be null terminated.)
-         * The information from tags 93 and 94 is embedded in the Class Identifier string
-         * xxxxx = Client Sys Architecture 0 . 65535
-         * yyy = UNDI Major version 0 . 255
-         * zzz = UNDI Minor version 0 . 255
-         *
-         * The Client Network Interface Identifier specifies the version of the UNDI API
-         * (described below) that will support a universal network driver. The UNDI interface
-         * must be supported and its version reported in tag #94.
-         *
-         * 3) System architecture type list from RFC4578:
+        /*
+         * System architecture type list from RFC4578:
          *             Type   Architecture Name
          *             ----   -----------------
          *              0    Intel x86PC
@@ -289,12 +272,6 @@ function messageHandlerFactory(
          *              8    EFI Xscale
          *              9    EFI x86-64
          */
-        if (packetData.options.archType === 0 &&
-                packetData.options.vendorClassIdentifier &&
-                packetData.options.vendorClassIdentifier.indexOf('UNDI') !== -1) {
-            return 'monorail-undionly.kpxe';
-        }
-
         if (packetData.options.vendorClassIdentifier) {
             if (packetData.options.archType === 7 || packetData.options.archType === 9) {
                 return 'monorail-efi64-snponly.efi';
@@ -302,6 +279,32 @@ function messageHandlerFactory(
             if (packetData.options.archType === 6) {
                 return 'monorail-efi32-snponly.efi';
             }
+
+            /* Notes for UNDI
+             * 1) Some NICs support UNDI driver, it needs chainload ipxe's undionly.kpxe file to
+             * bootup otherwise it will hang using monorail.ipxe. NOTE: if 'UNDI' is in class
+             * identifier but cannot boot for some NICs, please use MAC address or other
+             * condition to judge if use monorail-undionly.kpxe or not, or report it as a bug for
+             * this NIC.
+             *
+             * 2) Some Notes from PXE spec about DHCP options:
+             * PXEClient:Arch:xxxxx:UNDI:yyyzzz used for  transactions between client and server.
+             * (These strings are case sensitive. This field must not be null terminated.)
+             * The information from tags 93 and 94 is embedded in the Class Identifier string
+             * xxxxx = Client Sys Architecture 0 . 65535
+             * yyy = UNDI Major version 0 . 255
+             * zzz = UNDI Minor version 0 . 255
+             *
+             * The Client Network Interface Identifier specifies the version of the UNDI API
+             * (described below) that will support a universal network driver. The UNDI interface
+             * must be supported and its version reported in tag #94.
+             *
+             */
+            if (packetData.options.archType === 0 &&
+                    packetData.options.vendorClassIdentifier.indexOf('PXEClient:Arch:00000:UNDI') === 0) { // jshint ignore:line
+                return 'monorail-undionly.kpxe';
+            }
+
             return 'monorail.ipxe';
         }
     };

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -222,6 +222,12 @@ function messageHandlerFactory(
         assert.object(packetData.options);
         assert.string(packetData.chaddr.address);
 
+        logger.debug("DHCP packetData:", {
+            userClass: packetData.options.userClass,
+            vendorClassIdentifier: packetData.options.vendorClassIdentifier,
+            archType: packetData.options.archType
+        });
+
         // Defaults if we don't have an override from an active task
         if (packetData.options.userClass === "MonoRail") {
             return "http://" + configuration.get('apiServerAddress', '10.1.1.1') + ":" +
@@ -251,8 +257,40 @@ function messageHandlerFactory(
             return 'monorail.intel.ipxe';
         }
 
-        // Some NICs use UNDI driver, it needs chainload ipxe's undionly.kpxe file to bootup
-        if (packetData.options.vendorClassIdentifier &&
+        /* Notes for UNDI
+         * 1) Some NICs support UNDI driver, it needs chainload ipxe's undionly.kpxe file to bootup
+         * otherwise it will hang using monorail.ipxe. NOTE: if 'UNDI' is in class identifier
+         * but cannot boot for some NICs, please use MAC address or other condition to
+         * judge if use monorail-undionly.kpxe or not
+         *
+         * 2) Some Notes from PXE spec about DHCP options:
+         * PXEClient:Arch:xxxxx:UNDI:yyyzzz used for  transactions between client and server.
+         * (These strings are case sensitive. This field must not be null terminated.)
+         * The information from tags 93 and 94 is embedded in the Class Identifier string
+         * xxxxx = Client Sys Architecture 0 . 65535
+         * yyy = UNDI Major version 0 . 255
+         * zzz = UNDI Minor version 0 . 255
+         *
+         * The Client Network Interface Identifier specifies the version of the UNDI API
+         * (described below) that will support a universal network driver. The UNDI interface
+         * must be supported and its version reported in tag #94.
+         *
+         * 3) System architecture type list from RFC4578:
+         *             Type   Architecture Name
+         *             ----   -----------------
+         *              0    Intel x86PC
+         *              1    NEC/PC98
+         *              2    EFI Itanium
+         *              3    DEC Alpha
+         *              4    Arc x86
+         *              5    Intel Lean Client
+         *              6    EFI IA32
+         *              7    EFI BC
+         *              8    EFI Xscale
+         *              9    EFI x86-64
+         */
+        if (packetData.options.archType === 0 &&
+                packetData.options.vendorClassIdentifier &&
                 packetData.options.vendorClassIdentifier.indexOf('UNDI') !== -1) {
             return 'monorail-undionly.kpxe';
         }

--- a/spec/lib/message-handler-spec.js
+++ b/spec/lib/message-handler-spec.js
@@ -412,7 +412,12 @@ describe("MessageHandler", function() {
             expect(messageHandler.getDefaultBootfile(packetData)).to.equal('monorail.intel.ipxe');
         });
 
-        it("should return the default ipxe script if no special cases are met", function() {
+        it("should return customized monorail undionly.kpxe for UNDI pxe dhcp request", function() {
+            packetData.options.vendorClassIdentifier = 'PXEClient:Arch:00000:UNDI:002001';
+            expect(messageHandler.getDefaultBootfile(packetData)).to.equal('monorail-undionly.kpxe');
+        });
+
+        it("should return the default customized monorail ipxe if no special cases are met", function() {
             packetData.options.vendorClassIdentifier = 'testVendorClass';
             expect(messageHandler.getDefaultBootfile(packetData)).to.equal('monorail.ipxe');
         });

--- a/spec/lib/message-handler-spec.js
+++ b/spec/lib/message-handler-spec.js
@@ -413,6 +413,7 @@ describe("MessageHandler", function() {
         });
 
         it("should return customized monorail undionly.kpxe for UNDI pxe dhcp request", function() {
+            packetData.options.archType = 0;
             packetData.options.vendorClassIdentifier = 'PXEClient:Arch:00000:UNDI:002001';
             expect(messageHandler.getDefaultBootfile(packetData))
                 .to.equal('monorail-undionly.kpxe');

--- a/spec/lib/message-handler-spec.js
+++ b/spec/lib/message-handler-spec.js
@@ -414,10 +414,12 @@ describe("MessageHandler", function() {
 
         it("should return customized monorail undionly.kpxe for UNDI pxe dhcp request", function() {
             packetData.options.vendorClassIdentifier = 'PXEClient:Arch:00000:UNDI:002001';
-            expect(messageHandler.getDefaultBootfile(packetData)).to.equal('monorail-undionly.kpxe');
+            expect(messageHandler.getDefaultBootfile(packetData))
+                .to.equal('monorail-undionly.kpxe');
         });
 
-        it("should return the default customized monorail ipxe if no special cases are met", function() {
+        it("should return the default customized monorail ipxe if no special" +
+                "cases are met", function() {
             packetData.options.vendorClassIdentifier = 'testVendorClass';
             expect(messageHandler.getDefaultBootfile(packetData)).to.equal('monorail.ipxe');
         });


### PR DESCRIPTION
In some platforms such as platfrom-I, the NIC use UNDI driver, and it need undionly,kpxe from ipxe instead of monorail.ipxe to chainload or bootup.

related PR
https://github.com/RackHD/RackHD/pull/153
https://github.com/RackHD/on-imagebuilder/pull/32

@RackHD/rackhd_dev @RackHD/corecommitters 

Update: update some notes for UNDI in codes