### PR TITLE
Prototype dhcpd.conf file supporting serving of scripts for cisco poap

### DIFF
--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -1,4 +1,4 @@
-# Copyright 2015, EMC, Inc.
+# Copyright 2016, EMC, Inc.
 
 default-lease-time 600;
 max-lease-time 7200;
@@ -16,8 +16,43 @@ deny duplicates;
 # have to hack syslog.conf to complete the redirection).
 log-facility local7;
 
+option tftp-server code 66 = string;
+
+class "arista" {
+        match if substring (hardware, 1, 3) = 00:1c:73;
+}
+class "cisco" {
+        match if substring (hardware, 1, 3) = b0:aa:77;
+}
+
 subnet 10.1.1.0 netmask 255.255.255.0 {
-  range 10.1.1.2 10.1.1.254;
-  # Use this option to signal to the PXE client that we are doing proxy DHCP
-  option vendor-class-identifier "PXEClient";
+ # cisco switches
+ pool {
+        allow members of "cisco";
+        # Cisco POAP requires a minimum lease time of 3600 seconds
+        default-lease-time 3600;
+        range 10.1.1.231 10.1.1.240;
+
+        # Cisco POAP required DHCP options
+        option routers 10.1.1.1;
+        option domain-name-servers 10.1.1.1;
+        option tftp-server "10.1.1.1";
+
+        # Cisco POAP only supports TFTP downloads
+        option bootfile-name "cisco-poap.py";
+ }
+ # arista switches
+ pool {
+        allow members of "arista";
+        range 10.1.1.241 10.1.1.250;
+
+        # Arista ZTP supports downloading python/bash scripts directly via http
+        option bootfile-name "http://10.1.1.1:9080/api/current/profiles/switch/arista";
+ }
+ # compute nodes
+ pool {
+        range 10.1.1.2 10.1.1.230;
+        # Use this option to signal to the PXE client that we are doing proxy DHCP
+        option vendor-class-identifier "PXEClient";
+ }
 }


### PR DESCRIPTION
Adding an example dhcp configuration that enables Cisco POAP (bootstrap discovery and configuration of Cisco switches).

Supports:
https://github.com/RackHD/on-http/pull/210
https://github.com/RackHD/on-taskgraph/pull/84

@RackHD/corecommitters @heckj @pscharla @johren 

FYI @dpasupathi this is one way to enable things like option 66 with a vanilla RackHD deployment (see lines 19 and 39). I believe you were asking about this a while back.