### PR TITLE
add debug to make-deb.sh

### DIFF
--- a/extra/make-deb.sh
+++ b/extra/make-deb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 # Ensure we're always in the right directory.
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"

--- a/extra/make-deb.sh
+++ b/extra/make-deb.sh
@@ -5,7 +5,13 @@ set -ex
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 cd $SCRIPT_DIR/..
 
-BRANCH=$(git symbolic-ref --short -q HEAD)
+# Use the TRAVIS_BRANCH var if defined as travis vm
+# doesn't run the git symbolic-ref command.
+if [ -z "$TRAVIS_BRANCH" ]; then
+   BRANCH=$(git symbolic-ref --short -q HEAD)
+else
+   BRANCH=${TRAVIS_BRANCH}
+fi
 
 if [ -z "$DEBFULLNAME" ]; then
         export DEBFULLNAME=`git log -n 1 --pretty=format:%an`


### PR DESCRIPTION
This enables debugging in the make-deb script and fixes an issue discovered with how the BRANCH variable was calculated.

Here is a log before the BRANCH fix: https://travis-ci.org/ytjohn/on-dhcp-proxy/jobs/124656993#L743-L744

We see that the git command returns nothing, so the script exits out. So we fix it to check for the TRAVIS_BRANCH is set. Apparently the way travis clones git (shallow) is different than how I have it locally.

Once fixed: https://travis-ci.org/ytjohn/on-dhcp-proxy/jobs/124658066#L737-L744

The failure in that run is for the deploy, which is expected on this fork.
