### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,6 @@ Dockerfile
 gruntfile.js
 HWIMO-*
 LICENSE
+node_modules/
 README.md
 spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,13 @@
 
 FROM rackhd/on-core
 
-RUN mkdir -p /RackHD/on-dhcp-proxy
+COPY . /RackHD/on-dhcp-proxy/
 WORKDIR /RackHD/on-dhcp-proxy
 
-COPY ./package.json /tmp/
-RUN cd /tmp \
-  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
+RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-core ./node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production
 
-COPY . /RackHD/on-dhcp-proxy/
-RUN cp -a -f /tmp/node_modules /RackHD/on-dhcp-proxy/
-
-EXPOSE 68/udp
-EXPOSE 4011
-
+EXPOSE 68/udp 4011
 CMD [ "node", "/RackHD/on-dhcp-proxy/index.js" ]


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.
