### PR TITLE
Use config tftpBindAddress instead of dhcpGateway for siaddr and sname

### DIFF
--- a/lib/packet.js
+++ b/lib/packet.js
@@ -45,9 +45,9 @@ function PacketFactory(protocol, configuration, _) {
             packet.fname = bootFileName;
 
             // Necessary, at least on vbox
-            packet.siaddr = configuration.get('dhcpGateway', '10.1.1.1');
+            packet.siaddr = configuration.get('tftpBindAddress', '10.1.1.1');
             // Not necessary, at least on vbox, but perhaps other clients will require these fields?
-            packet.sname = configuration.get('dhcpGateway', '10.1.1.1');
+            packet.sname = configuration.get('tftpBindAddress', '10.1.1.1');
 
             //EFI PXE listen on a different port => tell the server
             if ((packet.options.userClass === undefined) &&

--- a/spec/lib/packet-spec.js
+++ b/spec/lib/packet-spec.js
@@ -73,7 +73,7 @@ describe("Packet", function() {
 
         it("should create a proper ACK packet for proxyDHCP", function() {
             var testbootfile = 'testbootfile';
-            configuration.get.withArgs('dhcpGateway').returns('10.1.1.1');
+            configuration.get.withArgs('tftpBindAddress').returns('10.1.1.1');
             configuration.get.withArgs('broadcastaddr').returns('10.1.1.255');
 
             packetUtil.createProxyDhcpAck(testPacket, testbootfile);


### PR DESCRIPTION
Wrong IP :) We need this to match what on-tftp is listening on for the bootfile download.

@RackHD/corecommitters @heckj