### PR TITLE
add a mac address substring to recognize the cisco switches

### DIFF
--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -22,7 +22,9 @@ class "arista" {
         match if substring (hardware, 1, 3) = 00:1c:73;
 }
 class "cisco" {
-        match if substring (hardware, 1, 3) = b0:aa:77;
+        match if substring (hardware, 1, 3) = b0:aa:77
+        or substring (hardware, 1, 3) = 00:c1:64
+        or substring (hardware, 1, 3) = 00:42:68;
 }
 
 subnet 10.1.1.0 netmask 255.255.255.0 {
@@ -56,3 +58,4 @@ subnet 10.1.1.0 netmask 255.255.255.0 {
         option vendor-class-identifier "PXEClient";
  }
 }
+


### PR DESCRIPTION
adding a new OUI (Organizationally Unique Identifier) for cisco in order to catalog the  cisco C3164PQ switches.