### PR TITLE
Brocade VDX switch integration as part of switch discovery

### DIFF
--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -26,8 +26,24 @@ class "cisco" {
         or substring (hardware, 1, 3) = 00:c1:64
         or substring (hardware, 1, 3) = 00:42:68;
 }
+class "brocade" {
+        match if substring (hardware, 1, 3) = 00:05:33;
+}
 
 subnet 10.1.1.0 netmask 255.255.255.0 {
+ #brocade switches
+ pool {
+        allow members of "brocade";
+        default-lease-time 60000;
+        range 10.1.1.221 10.1.1.230;
+
+	# Brocade ZTP requires FTP server and DAD conf file 
+        # option 66 should be FTP server address
+        # option 67 should be DAD conf file. This conf file 
+        # will contain name of wrapper script to download taskrunner.py
+        option bootfile-name "/brcd.conf";
+        option tftp-server-name "10.1.1.220";
+ }
  # cisco switches
  pool {
         allow members of "cisco";


### PR DESCRIPTION
Relevant to pull request on Rack-HD: Brocade VDX switch integration as part of switch discovery #331 

Added brocade specific identifier in the dhcpd.conf file