### PR TITLE
Separate on-dhcp-proxy to be loosely-coupled with RackHD

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -30,17 +30,12 @@ function messageHandlerFactory(
     Logger,
     assert,
     Errors,
-    Promise,
-    _
+    Promise
 ) {
     var logger = Logger.initialize(messageHandlerFactory);
 
     function MessageHandler() {
     }
-
-    MessageHandler.prototype.createActionHandler = function(packetData) {
-        return new ActionHandler(packetData, this.getDefaultBootfile.bind(this));
-    };
 
     MessageHandler.prototype.handleDhcpPacket = function(packet, sendCallback) {
         var self = this;
@@ -56,11 +51,11 @@ function messageHandlerFactory(
         }
 
         // Speed up response time by queueing both these async actions
-        return Promise.all([
-            self.getBootfile(packetData),
-            lookupService.setIpAddress(packetData.ciaddr, packetData.chaddr.address)
-        ])
-        .spread(function(bootFileName) {
+        return Promise.resolve()
+        .then(function(){
+            return self.getDefaultBootfile(packetData);
+        })
+        .then(function(bootFileName) {
             if (bootFileName) {
                 var responsePacket = packetUtil.createProxyDhcpAck(packetData, bootFileName);
                 sendCallback(responsePacket);
@@ -71,140 +66,6 @@ function messageHandlerFactory(
                 error: err
             });
         });
-    };
-
-    /*
-     * Return the next action to take based on whether a node is known or unknown.
-     *
-     * @member
-     * @function
-     *
-     * @param {String} macAddress - mac address of PXE client
-     * @returns {Promise}
-     */
-    MessageHandler.prototype.getNodeAction = function(macAddress) {
-        var resolve;
-        var deferred = new Promise(function(_resolve) {
-            resolve = _resolve;
-        });
-        var out = {};
-
-        lookupService.macAddressToNode(macAddress)
-        .then(function(node) {
-            return node.discovered()
-            .then(function(discovered) {
-                // We only count a node as having been discovered if
-                // a node document exists AND it has any catalogs
-                // associated with it
-                if (discovered) {
-                    out.action = 'next';
-                    out.data = node.id;
-                } else {
-                    out.action = 'discover';
-                }
-                resolve(out);
-            });
-        })
-        .catch(function(err) {
-            if (err instanceof Errors.NotFoundError) {
-                out.action = 'discover';
-                resolve(out);
-            } else {
-                logger.debug(
-                    "Ignoring DHCP requests from node because of a lookup failure.", {
-                        macaddress: macAddress,
-                        error: err
-                    }
-                );
-                out.action = 'ignore';
-                resolve(out);
-            }
-        });
-
-        return deferred;
-    };
-
-    /*
-     * Return the next action to take based on whether a known node has an
-     * active task associated with it.
-     *
-     * @member
-     * @function
-     *
-     * @param {String} nodeId - nodeId used to request an active task
-     * @returns {Promise}
-     */
-    MessageHandler.prototype.getKnownNodeAction = function(nodeId) {
-        var resolve;
-        var deferred = new Promise(function(_resolve) {
-            resolve = _resolve;
-        });
-        var out = {};
-
-        taskProtocol.activeTaskExists(nodeId)
-        .then(function() {
-            out.action = 'next';
-            out.data = nodeId;
-            resolve(out);
-        })
-        .catch(function() {
-            logger.debug("There is no active task assigned to node, " +
-                "then check node bootSettings", { id: nodeId });
-
-            return waterline.nodes.findByIdentifier(nodeId)
-            .then(function(node) {
-                if (_.has(node, 'bootSettings')) {
-                    out.action = 'next';
-                    out.data = nodeId;
-                } else {
-                    logger.debug("Ignoring DHCP requests from node, " +
-                        "because it doesn't have bootSettings and active task.", { id: nodeId });
-                    out.action = 'ignore';
-                }
-                resolve(out);
-            })
-            .catch(function() {
-                logger.debug("Ignoring DHCP requests from node, " +
-                    "because it cannot find node with identifier.", { id: nodeId });
-                out.action = 'ignore';
-                resolve(out);
-            });
-        });
-
-        return deferred;
-    };
-
-    /*
-     * Return the next action to take based on whether a known node has an
-     * active task associated with it.
-     *
-     * @member
-     * @function
-     *
-     * @param {String} nodeId - nodeId used to request a bootfile from the active task
-     * @returns {Promise}
-     */
-    MessageHandler.prototype.getKnownNodeActionFromTask = function(nodeId) {
-        var resolve;
-        var deferred = new Promise(function(_resolve) {
-            resolve = _resolve;
-        });
-        var out = {};
-
-        taskProtocol.getBootProfile(nodeId)
-        .then(function(bootFileName) {
-            out.action = 'send-custom-bootfile';
-            out.data = bootFileName;
-            resolve(out);
-        })
-        .catch(function(error) {
-            logger.warning("Could not get TFTP bootfile name from active task. " +
-                "Sending default bootfile.", { error: error });
-            out.action = 'send-default-bootfile';
-            resolve(out);
-        });
-
-        return deferred;
     };
 
     /*
@@ -306,94 +167,6 @@ function messageHandlerFactory(
             }
 
             return 'monorail.ipxe';
-        }
-    };
-
-    /*
-     * Determine what boot file, if any, to return to a PXE client
-     *
-     * @member
-     * @function
-     *
-     * @param {Object} packetData - A parsed DHCP packet
-     * @returns {Promise}
-     */
-    MessageHandler.prototype.getBootfile = function(packetData) {
-        var self = this;
-        var actionHandler = self.createActionHandler(packetData);
-
-        self.getNodeAction(packetData.chaddr.address)
-        .then(function(out) {
-            return actionHandler.handleAction(self.getKnownNodeAction, out.action, out.data);
-        })
-        .then(function(out) {
-            return actionHandler.handleAction(
-                self.getKnownNodeActionFromTask, out.action, out.data);
-        })
-        .then(function(out) {
-            return actionHandler.handleAction(self.getDefaultBootfile, out.action, out.data);
-        })
-        .catch(Errors.BreakPromiseChainError, function() {
-            return;
-        })
-        .catch(function(err) {
-            actionHandler.reject(err);
-        });
-
-        return actionHandler.deferred;
-    };
-
-    /*
-     * A simple logic handler called at each step in the decision pipeline for
-     * determining a DHCP boot file name for a node
-     *
-     * @constructor
-     */
-    function ActionHandler(packetData, getDefaultBootfileFn) {
-        var self = this;
-        self.deferred = new Promise(function(resolve, reject) {
-            self.resolve = resolve;
-            self.reject = reject;
-        });
-        self.packetData = packetData;
-        self.getDefaultBootfile = getDefaultBootfileFn;
-    }
-
-    /*
-     * @member
-     * @function
-     *
-     * @param {Function} nextFn - next function in decision pipeline
-     * @param {String} action - DHCP boot file action, if 'next' will call nextFn
-     * @param {String} data - parameter to pass into nextFn if action is 'next'
-     *
-     * @returns {Promise}
-     */
-    ActionHandler.prototype.handleAction = function(nextFn, action, data) {
-        assert.func(nextFn);
-        assert.string(action);
-
-        if (action === 'discover') {
-            assert.object(this.packetData);
-            logger.debug(
-                "Unknown node %s. Sending down default bootfile."
-                    .format(this.packetData.chaddr.address)
-            );
-            this.resolve(this.getDefaultBootfile(this.packetData));
-            throw new Errors.BreakPromiseChainError();
-        } else if (action === 'ignore') {
-            this.resolve(null);
-            throw new Errors.BreakPromiseChainError();
-        } else if (action === 'next') {
-            return nextFn(data);
-        } else if (action === 'send-default-bootfile') {
-            this.resolve(this.getDefaultBootfile(this.packetData));
-            throw new Errors.BreakPromiseChainError();
-        } else if (action === 'send-custom-bootfile') {
-            this.resolve(data);
-            throw new Errors.BreakPromiseChainError();
-        } else {
-            throw new Error('Unrecognized action');
         }
     };
 

--- a/spec/lib/message-handler-spec.js
+++ b/spec/lib/message-handler-spec.js
@@ -4,7 +4,6 @@
 "use strict";
 
 describe("MessageHandler", function() {
-    var lookupService;
     var Errors;
     var messageHandler;
     var packetData;
@@ -20,9 +19,6 @@ describe("MessageHandler", function() {
                 helper.require('/lib/dhcp-protocol')
             ]
         );
-
-        lookupService = helper.injector.get('Services.Lookup');
-        sinon.stub(lookupService, 'setIpAddress').resolves();
         Errors = helper.injector.get('Errors');
         var Logger = helper.injector.get('Logger');
         Promise = helper.injector.get('Promise');
@@ -38,330 +34,6 @@ describe("MessageHandler", function() {
             ciaddr: '10.1.1.11',
             options: {}
         };
-    });
-
-    after("MessageHandler after", function() {
-        lookupService.setIpAddress.restore();
-    });
-
-    describe("ActionHandler", function() {
-        var actionHandler;
-        var thrown;
-        var nextFn = function () {};
-
-        beforeEach("ActionHandler beforeEach", function() {
-            actionHandler = messageHandler.createActionHandler(packetData);
-            sinon.stub(actionHandler, 'getDefaultBootfile');
-            thrown = false;
-        });
-
-        it("should resolve default bootfile on discover action", function() {
-            var testDefaultBootfile = 'test-default-bootfile';
-            actionHandler.getDefaultBootfile.returns(testDefaultBootfile);
-
-            return Promise.resolve()
-            .then(function() {
-                return actionHandler.handleAction(nextFn, 'discover', undefined);
-            })
-            .catch(function(error) {
-                thrown = true;
-                expect(error).to.be.an.instanceof(Errors.BreakPromiseChainError);
-            })
-            .then(function() {
-                expect(thrown).to.equal(true);
-                return actionHandler.deferred;
-            })
-            .then(function(out) {
-                expect(out).to.equal(testDefaultBootfile);
-                expect(actionHandler.getDefaultBootfile)
-                    .to.have.been.calledWith(actionHandler.packetData);
-            });
-        });
-
-        it("should do nothing on ignore action", function() {
-            return Promise.resolve()
-            .then(function() {
-                return actionHandler.handleAction(nextFn, 'ignore', undefined);
-            })
-            .catch(function(error) {
-                thrown = true;
-                expect(error).to.be.an.instanceof(Errors.BreakPromiseChainError);
-            })
-            .then(function() {
-                expect(thrown).to.equal(true);
-                return actionHandler.deferred;
-            })
-            .then(function(out) {
-                expect(out).to.equal(null);
-            });
-        });
-
-        it("should call next on next action", function() {
-            var nextOut = { action: 'test' };
-            var nextStub = sinon.stub().resolves(nextOut);
-            var data = 'testdata';
-
-            return Promise.resolve()
-            .then(function() {
-                return actionHandler.handleAction(nextStub, 'next', data);
-            })
-            .then(function(out) {
-                expect(out).to.equal(nextOut);
-                expect(nextStub).to.have.been.calledWith(data);
-            });
-        });
-
-        it("should resolve default bootfile on send-default-bootfile action", function() {
-            var testDefaultBootfile = 'test-default-bootfile';
-            actionHandler.getDefaultBootfile.returns(testDefaultBootfile);
-
-            return Promise.resolve()
-            .then(function() {
-                return actionHandler.handleAction(nextFn, 'send-default-bootfile', undefined);
-            })
-            .catch(function(error) {
-                thrown = true;
-                expect(error).to.be.an.instanceof(Errors.BreakPromiseChainError);
-            })
-            .then(function() {
-                expect(thrown).to.equal(true);
-                return actionHandler.deferred;
-            })
-            .then(function(out) {
-                expect(out).to.equal(testDefaultBootfile);
-                expect(actionHandler.getDefaultBootfile)
-                    .to.have.been.calledWith(actionHandler.packetData);
-            });
-        });
-
-        it("should resolve task-specified bootfile on send-custom-bootfile action", function() {
-            var testCustomBootfile = 'test-custom-bootfile';
-
-            return Promise.resolve()
-            .then(function() {
-                return actionHandler.handleAction(
-                    nextFn, 'send-custom-bootfile', testCustomBootfile);
-            })
-            .catch(function(error) {
-                thrown = true;
-                expect(error).to.be.an.instanceof(Errors.BreakPromiseChainError);
-            })
-            .then(function() {
-                expect(thrown).to.equal(true);
-                return actionHandler.deferred;
-            })
-            .then(function(out) {
-                expect(out).to.equal(testCustomBootfile);
-            });
-        });
-
-        it("should throw on an unrecognized action", function() {
-        });
-    });
-
-    describe("getNodeAction", function() {
-        var Errors;
-        var node;
-
-        before("MessageHandler:getNodeAction before", function() {
-            Errors = helper.injector.get('Errors');
-            sinon.stub(lookupService, 'macAddressToNode');
-            node = {
-                discovered: sinon.stub(),
-                id: 'testnodeid'
-            };
-        });
-
-        beforeEach("MessageHandler:getNodeAction beforeEach", function() {
-            lookupService.macAddressToNode.reset();
-            node.discovered.rejects(new Error('override in test'));
-            node.discovered.reset();
-        });
-
-        after("MessageHandler:getNodeAction after", function() {
-            lookupService.macAddressToNode.restore();
-        });
-
-        it("should call lookupService.macAddressToNode with node mac address", function() {
-            node.discovered.resolves(false);
-            lookupService.macAddressToNode.resolves(node);
-            return messageHandler.getNodeAction(packetData.chaddr.address)
-            .then(function() {
-                expect(lookupService.macAddressToNode)
-                    .to.have.been.calledWith(packetData.chaddr.address);
-            });
-        });
-
-        it("should get the node action for a new node", function() {
-            lookupService.macAddressToNode.rejects(new Errors.NotFoundError(''));
-
-            return messageHandler.getNodeAction(packetData.chaddr.address)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('discover');
-            });
-        });
-
-        it("should ignore a node on an unknown lookup failure", function() {
-            lookupService.macAddressToNode.rejects(new Error(''));
-
-            return messageHandler.getNodeAction(packetData.chaddr.address)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('ignore');
-            });
-        });
-
-        it("should get the action for a node if it is has already been discovered", function() {
-            node.discovered.resolves(true);
-            lookupService.macAddressToNode.resolves(node);
-
-            return messageHandler.getNodeAction(packetData.chaddr.address)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('next');
-                expect(out).to.have.property('data').that.equals(testnodeid);
-            });
-        });
-
-        it("should get the action for a known node if it has not been discovered", function() {
-            node.discovered.resolves(false);
-            lookupService.macAddressToNode.resolves(node);
-
-            return messageHandler.getNodeAction(packetData.chaddr.address)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('discover');
-            });
-        });
-    });
-
-    describe("getKnownNodeAction", function() {
-        var taskProtocol;
-        var waterline;
-
-        before("MessageHandler.getKnownNodeAction before", function() {
-            taskProtocol = helper.injector.get('Protocol.Task');
-            waterline = helper.injector.get('Services.Waterline');
-            waterline.nodes = {
-                findByIdentifier: function() {}
-            };
-            sinon.stub(taskProtocol, 'activeTaskExists');
-            sinon.stub(waterline.nodes, 'findByIdentifier');
-        });
-
-        beforeEach("MessageHandler.getKnownNodeAction beforeEach", function() {
-            taskProtocol.activeTaskExists.reset();
-            waterline.nodes.findByIdentifier.reset();
-        });
-
-        after("MessageHandler.getKnownNodeAction after", function() {
-            taskProtocol.activeTaskExists.restore();
-        });
-
-        it("should call taskProtocol.activeTaskExists with node id", function() {
-            var testnodeid = 'testnodeid';
-            taskProtocol.activeTaskExists.resolves();
-
-            return messageHandler.getKnownNodeAction(testnodeid)
-            .then(function() {
-                expect(taskProtocol.activeTaskExists).to.have.been.calledWith(testnodeid);
-            });
-        });
-
-        it("should get the action for a known node if it does not have an active task" +
-                " and does not have bootSettings", function() {
-
-            var node = { id: "testnodeid" };
-
-            taskProtocol.activeTaskExists.rejects(new Error(''));
-            waterline.nodes.findByIdentifier.resolves(node);
-
-            return messageHandler.getKnownNodeAction('testnodeid')
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('ignore');
-            });
-        });
-
-        it("should get the action for a known node if it does not have an active task" +
-                " and have bootSettings", function() {
-
-            var node = { id: "testnodeid", bootSettings: {} };
-
-            taskProtocol.activeTaskExists.rejects(new Error(''));
-            waterline.nodes.findByIdentifier.resolves(node);
-
-            return messageHandler.getKnownNodeAction('testnodeid')
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('next');
-                expect(out).to.have.property('data').that.equals(testnodeid);
-            });
-        });
-
-        it("should get the action for a known node if it does not have an active task" +
-                " and has exceptions when findByIdentifier", function() {
-
-            taskProtocol.activeTaskExists.rejects(new Error(''));
-            waterline.nodes.findByIdentifier.rejects(new Error(''));
-
-            return messageHandler.getKnownNodeAction('testnodeid')
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('ignore');
-            });
-        });
-
-        it("should get the action for a known node if it has an active task", function() {
-            taskProtocol.activeTaskExists.resolves(testnodeid);
-
-            return messageHandler.getKnownNodeAction(testnodeid)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('next');
-                expect(out).to.have.property('data').that.equals(testnodeid);
-            });
-        });
-    });
-
-    describe("getKnownNodeActionFromTask", function() {
-        var taskProtocol;
-
-        before("MessageHandler.getKnownNodeActionFromTask before", function() {
-            taskProtocol = helper.injector.get('Protocol.Task');
-            sinon.stub(taskProtocol, 'getBootProfile');
-        });
-
-        beforeEach("MessageHandler.getKnownNodeActionFromTask beforeEach", function() {
-            taskProtocol.getBootProfile.reset();
-        });
-
-        after("MessageHandler.getKnownNodeActionFromTask after", function() {
-            taskProtocol.getBootProfile.restore();
-        });
-
-        it("should call taskProtocol.getBootProfile with node id", function() {
-            var testnodeid = 'testnodeid';
-            taskProtocol.getBootProfile.resolves();
-
-            return messageHandler.getKnownNodeActionFromTask(testnodeid)
-            .then(function() {
-                expect(taskProtocol.getBootProfile).to.have.been.calledWith(testnodeid);
-            });
-        });
-
-        it("should specify the default bootfile action if the task does not set one", function() {
-            taskProtocol.getBootProfile.rejects(new Error(''));
-
-            return messageHandler.getKnownNodeActionFromTask(testnodeid)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('send-default-bootfile');
-            });
-        });
-
-        it("should specify the custom bootfile action if the task sets one", function() {
-            var testBootfile = 'testBootfile';
-            taskProtocol.getBootProfile.resolves(testBootfile);
-
-            return messageHandler.getKnownNodeActionFromTask(testnodeid)
-            .then(function(out) {
-                expect(out).to.have.property('action').that.equals('send-custom-bootfile');
-                expect(out).to.have.property('data').that.equals(testBootfile);
-            });
-        });
     });
 
     describe("getDefaultBootfile", function() {
@@ -427,96 +99,6 @@ describe("MessageHandler", function() {
         });
     });
 
-    describe("getBootfile", function() {
-        before("MessageHandler.getBootfile before", function() {
-            sinon.stub(messageHandler, 'getDefaultBootfile');
-            sinon.stub(messageHandler, 'getNodeAction');
-            sinon.stub(messageHandler, 'getKnownNodeAction');
-            sinon.stub(messageHandler, 'getKnownNodeActionFromTask');
-        });
-
-        beforeEach("MessageHandler.getBootfile beforeEach", function() {
-            messageHandler.getDefaultBootfile.reset();
-            messageHandler.getNodeAction.reset();
-            messageHandler.getKnownNodeAction.reset();
-            messageHandler.getKnownNodeActionFromTask.reset();
-        });
-
-        after("MessageHandler.getBootfile after", function() {
-            messageHandler.getDefaultBootfile.restore();
-            messageHandler.getNodeAction.restore();
-            messageHandler.getKnownNodeAction.restore();
-            messageHandler.getKnownNodeActionFromTask.restore();
-        });
-
-        it("should return a bootfile for an unknown node", function() {
-            var bootfile = 'test.ipxe';
-            messageHandler.getNodeAction.resolves({ action: 'discover' });
-            messageHandler.getDefaultBootfile.returns(bootfile);
-
-            return messageHandler.getBootfile(packetData)
-            .then(function(_bootfile) {
-                expect(messageHandler.getNodeAction).to.have.been.calledOnce;
-                expect(messageHandler.getKnownNodeAction).to.not.have.been.called;
-                expect(messageHandler.getKnownNodeActionFromTask).to.not.have.been.called;
-                expect(_bootfile).to.equal(bootfile);
-            });
-        });
-
-        it("should not return a bootfile for a known node with no active task", function() {
-            var testnodeid = 'testnodeid';
-            messageHandler.getNodeAction.resolves({ action: 'next', data: testnodeid });
-            messageHandler.getKnownNodeAction.resolves({ action: 'ignore' });
-
-            return messageHandler.getBootfile(packetData)
-            .then(function(_bootfile) {
-                expect(messageHandler.getNodeAction).to.have.been.calledOnce;
-                expect(messageHandler.getKnownNodeAction).to.have.been.calledWith(testnodeid);
-                expect(messageHandler.getKnownNodeActionFromTask).to.not.have.been.called;
-                expect(_bootfile).to.equal(null);
-            });
-        });
-
-        it("should return a default bootfile for known node with an active task", function() {
-            var bootfile = 'test.ipxe';
-            var testnodeid = 'testnodeid';
-            messageHandler.getNodeAction.resolves({ action: 'next', data: testnodeid });
-            messageHandler.getKnownNodeAction.resolves({ action: 'next', data: testnodeid });
-            messageHandler.getKnownNodeActionFromTask.resolves({ action: 'send-default-bootfile' });
-            messageHandler.getDefaultBootfile.returns(bootfile);
-
-            return messageHandler.getBootfile(packetData)
-            .then(function(_bootfile) {
-                expect(messageHandler.getNodeAction).to.have.been.calledOnce;
-                expect(messageHandler.getKnownNodeAction).to.have.been.calledOnce;
-                expect(messageHandler.getKnownNodeActionFromTask).to.have.been.calledOnce;
-                expect(_bootfile).to.equal(bootfile);
-            });
-        });
-
-        it("should return a custom bootfile for known node with an active task", function() {
-            var bootfile = 'testcustom.ipxe';
-            messageHandler.getNodeAction.resolves({ action: 'next', data: testnodeid });
-            messageHandler.getKnownNodeAction.resolves({ action: 'next', data: testnodeid });
-            messageHandler.getKnownNodeActionFromTask.resolves(
-                { action: 'send-custom-bootfile', data: bootfile }
-            );
-
-            return messageHandler.getBootfile(packetData)
-            .then(function(_bootfile) {
-                expect(messageHandler.getNodeAction).to.have.been.calledOnce;
-                expect(messageHandler.getKnownNodeAction).to.have.been.calledOnce;
-                expect(messageHandler.getKnownNodeActionFromTask).to.have.been.calledOnce;
-                expect(_bootfile).to.equal(bootfile);
-            });
-        });
-
-        it("should reject on internal failures getting node data", function() {
-            messageHandler.getNodeAction.rejects(new Error('Test Error'));
-            return expect(messageHandler.getBootfile(packetData)).to.be.rejectedWith(/Test Error/);
-        });
-    });
-
     describe("handleDhcpPacket", function() {
         var parser;
         var packetUtil;
@@ -525,27 +107,27 @@ describe("MessageHandler", function() {
             packetUtil = helper.injector.get('DHCP.packet');
             parser = helper.injector.get('DHCP.parser');
 
-            sinon.stub(messageHandler, 'getBootfile');
+            sinon.stub(messageHandler, 'getDefaultBootfile');
             sinon.stub(packetUtil, 'createProxyDhcpAck');
             sinon.stub(parser, 'parse');
+        });
+
+        beforeEach("MessageHandler.handleDhcpPacket beforeEach", function() {
+            messageHandler.getDefaultBootfile.reset();
+            packetUtil.createProxyDhcpAck.reset();
 
             parser.parse.returns(packetData);
         });
 
-        beforeEach("MessageHandler.handleDhcpPacket beforeEach", function() {
-            messageHandler.getBootfile.reset();
-            packetUtil.createProxyDhcpAck.reset();
-        });
-
         after("MessageHandler.handleDhcpPacket after", function() {
-            messageHandler.getBootfile.restore();
+            messageHandler.getDefaultBootfile.restore();
             packetUtil.createProxyDhcpAck.restore();
             parser.parse.restore();
         });
 
         it("should not call the send callback if not bootfile is specified", function() {
             var stubCallback = sinon.stub();
-            messageHandler.getBootfile.resolves(null);
+            messageHandler.getDefaultBootfile.resolves(null);
 
             return messageHandler.handleDhcpPacket(null, stubCallback)
             .then(function() {
@@ -553,22 +135,11 @@ describe("MessageHandler", function() {
             });
         });
 
-        it("should not call the send callback if lookupService.setIpAddress " +
-            "resolves null", function() {
-            var stubCallback = sinon.stub();
-            lookupService.setIpAddress.resolves(null);
-
-            return messageHandler.handleDhcpPacket(null, stubCallback)
-                .then(function() {
-                    expect(stubCallback).to.not.have.been.called;
-                });
-        });
-
         it("should call the send callback with a response packet", function() {
             var stubCallback = sinon.stub();
             var bootfile = 'testbootfile';
             packetUtil.createProxyDhcpAck.returns({ fname: bootfile });
-            messageHandler.getBootfile.resolves(bootfile);
+            messageHandler.getDefaultBootfile.resolves(bootfile);
 
             return messageHandler.handleDhcpPacket(null, stubCallback)
             .then(function() {
@@ -577,19 +148,5 @@ describe("MessageHandler", function() {
             });
         });
 
-        it("should call lookupService and set the Ip address with" +
-            " the response packet information", function() {
-            var bootfile = 'testbootfile';
-            var stubCallback = sinon.stub();
-            packetUtil.createProxyDhcpAck.returns({ fname: bootfile });
-            messageHandler.getBootfile.resolves(bootfile);
-
-            return messageHandler.handleDhcpPacket(null, stubCallback)
-                .then(function() {
-                    expect(lookupService.setIpAddress).to.have.been.calledWith(packetData.ciaddr,
-                        packetData.chaddr.address);
-                    expect(stubCallback).to.have.been.calledWith({ fname: bootfile });
-                });
-        });
     });
 });


### PR DESCRIPTION
PR for proposal PR for proposal https://groups.google.com/forum/#!topic/rackhd/I81Tl2qkQMI
requires PR https://github.com/RackHD/on-http/pull/411

maybe 'simplify on-dhcp-proxy' is more accurate. most duplicated code logic is removed. Removed code logic have been implemented in southbound API GET /profiles route

@RackHD/corecommitters  @benno  @jlongever 