### PR TITLE
Remove unused config broadcastaddr

### DIFF
--- a/spec/lib/packet-spec.js
+++ b/spec/lib/packet-spec.js
@@ -74,7 +74,6 @@ describe("Packet", function() {
         it("should create a proper ACK packet for proxyDHCP", function() {
             var testbootfile = 'testbootfile';
             configuration.get.withArgs('tftpBindAddress').returns('10.1.1.1');
-            configuration.get.withArgs('broadcastaddr').returns('10.1.1.255');
 
             packetUtil.createProxyDhcpAck(testPacket, testbootfile);
             var builtPacket = packetUtil.createPacketBuffer.firstCall.args[0];


### PR DESCRIPTION
‘broadcastaddr’ is not used in codes, remove it

related PR: https://github.com/RackHD/RackHD/pull/386

@RackHD/corecommitters 