### PR TITLE
Fix issue for PXE no free memory

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -53,18 +53,104 @@ function messageHandlerFactory(
         // Speed up response time by queueing both these async actions
         return Promise.resolve()
         .then(function(){
-            return self.getDefaultBootfile(packetData);
+            /*
+             * Workaround for 'Intel Boot Agent' PXE boot issue that
+             * no free memory when PXE boot ROM donwload files for severail times.
+             * In some physical machine that use Intel Boot Agent PXE boot,
+             * when the boot sequence is:
+             *      NIC1 PXE boot
+             *   -> Donwload iPXE bootfile, and chainload to iPXE boot for NIC1
+             *   -> Noting for NIC1 iPXE boot, continue to NIC2 PXE boot
+             *   -> Noting for NIC2 PXE boot, continue to NIC1 PXE boot 
+             *   -> Donwload iPXE bootfile, and chainload to iPXE boot for NIC1
+             *   -> .....(loop as above)
+             * NIC ROM firmware will download iPXE bootfile in multiple times,
+             * but memory is not freed. So after several times, no free memory left.
+             * Console will show 'NBP is too big to fit in free base memory',
+             * which will lead to physical machine cannot auto-boot in next time.
+             *
+             * Workaround this issue by a pre-check. If it's not neccesary,
+             * don't need to send iPXE bootfile name to let node download bootfile.
+             *
+             * The pre-check could be configured so that when there's no this issue,
+             * it could be disabled, and also keep the ability of separate DHCP.
+             */
+            var dhcpSendBootFileName = configuration.get('dhcpSendBootFileName', true);
+            if(dhcpSendBootFileName) {
+                return self.isBootFileNameSent(packetData);
+            } else {
+                return true;
+            }
+        })
+        .then(function(isBootFileNameSent) {
+            if (isBootFileNameSent) {
+                return self.getDefaultBootfile(packetData);
+            }
         })
         .then(function(bootFileName) {
             if (bootFileName) {
                 var responsePacket = packetUtil.createProxyDhcpAck(packetData, bootFileName);
                 sendCallback(responsePacket);
+                logger.info(bootFileName + " name is sent to node",
+                    { macaddress: packetData.chaddr.address });
+            } else {
+                logger.info("No bootfile name is sent to node",
+                    { macaddress: packetData.chaddr.address });
+
             }
         })
         .catch(function(err) {
             logger.warning("Failed to get bootfile information for " + packetData.chaddr.address, {
                 error: err
             });
+        });
+    };
+
+    /*
+     * Determine if bootfile name should be sent or not
+     * in the DHCP packet.
+     *
+     * @param {Object} packetData - A parsed DHCP packet
+     * @returns {Promise}
+     */
+    MessageHandler.prototype.isBootFileNameSent = function(packetData) {
+        var macAddress = packetData.chaddr.address;
+        return lookupService.macAddressToNode(macAddress)
+        .then(function(node) {
+            return node.discovered()
+            .then(function(discovered) {
+                if (discovered) {
+                    return taskProtocol.activeTaskExists(node.id)
+                    .then(function() {
+                        logger.info("Active task exists", { macaddress: macAddress });
+                        return true;
+                    })
+                    .catch(function(){
+                        if(node.hasOwnProperty('bootSettings')) {
+                            logger.info("There is bootSettings", { macaddress: macAddress });
+                            return true;
+                        } else {
+                            logger.info("Node is discovered, but no active task and boot setttings",
+                                { macaddress: macAddress });
+                            return false;
+                        }
+                    });
+                } else {
+                    logger.info("Node is not discovered", { macaddress: macAddress });
+                    return true;
+                }
+            });
+        })
+        .catch(function(err){
+            if (err instanceof Errors.NotFoundError) {
+                logger.info("There is no lookup record for this node", { macaddress: macAddress });
+                return true;
+            } else {
+                logger.error("A lookup failure occur",
+                    { macaddress: macAddress,
+                      error: err });
+                return false;
+            }
         });
     };
 


### PR DESCRIPTION
https://hwjiraprd01.corp.emc.com/browse/ODR-817


Workaround for 'Intel Boot Agent' PXE boot issue that   no free memory when PXE boot ROM donwload files for severail times. In some physical machine that use Intel Boot Agent PXE boot,
 when the boot sequence is:
    NIC1 PXE boot
 -> NIC1 donwload iPXE bootfile, and chainload to iPXE boot for NIC1
 -> Noting for NIC1 iPXE boot, continue to NIC2 PXE boot
 -> Noting for NIC2 PXE boot, continue to NIC1 PXE boot
 -> NIC1 donwload iPXE bootfile, and chainload to iPXE boot for NIC1
  -> .....(loop as above)
NIC ROM firmware will download iPXE bootfile in multiple times, but memory is not freed. So after several times, no free memory left. Console will show `NBP is too big to fit in free base memory`, which will lead to physical machine cannot auto-boot in next time.

Workaround this issue by a pre-check. If it's not neccesary, don't need to send iPXE bootfile name to let node download bootfile.

The pre-check could be configured so that when this issue doesn't exist for some vendor's physical machines, it could be disabled, and also keep the ability of separate DHCP, so by default, on-dhcp-proxy still has the same behavior as before PR https://github.com/RackHD/on-dhcp-proxy/pull/50, but on-dhcp-proxy still keep the ability for DHCP separation. 

@RackHD/corecommitters @pengz1 