### PR TITLE
Refine pre-check for boot process

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -122,8 +122,17 @@ function messageHandlerFactory(
                 if (discovered) {
                     return taskProtocol.activeTaskExists(node.id)
                     .then(function() {
-                        logger.info("Active task exists", { macaddress: macAddress });
-                        return true;
+                        return taskProtocol.requestProfile(node.id)
+                        .then(function () {
+                            logger.info("Active task exists, and profile exists",
+                                { macaddress: macAddress });
+                            return true;
+                        })
+                        .catch(function () {
+                            logger.info("Active task exists, but no profile exists",
+                                { macaddress: macAddress });
+                            return false;
+                        });
                     })
                     .catch(function(){
                         if(node.hasOwnProperty('bootSettings')) {

--- a/spec/lib/message-handler-spec.js
+++ b/spec/lib/message-handler-spec.js
@@ -176,6 +176,7 @@ describe("MessageHandler", function() {
 
             sinon.stub(lookupService, 'macAddressToNode');
             sinon.stub(taskProtocol, 'activeTaskExists');
+            sinon.stub(taskProtocol, 'requestProfile');
             node = {
                 discovered: sinon.stub(),
                 id: 'testnodeid'
@@ -185,12 +186,14 @@ describe("MessageHandler", function() {
         beforeEach("MessageHandler.isBootFileNameSent beforeEach", function() {
             lookupService.macAddressToNode.reset();
             taskProtocol.activeTaskExists.reset();
+            taskProtocol.requestProfile.reset();
             node.discovered.reset();
         });
 
         after("MessageHandler.isBootFileNameSent after", function() {
             lookupService.macAddressToNode.restore();
             taskProtocol.activeTaskExists.restore();
+            taskProtocol.requestProfile.restore();
         });
 
         it("should send bootfile name if node lookup is not found", function() {
@@ -221,14 +224,29 @@ describe("MessageHandler", function() {
             });
         });
 
-        it("should send bootfile name if node is discovered and has active tasks", function() {
+        it("should send bootfile name if node is discovered and has active tasks and profiles",
+        function() {
             lookupService.macAddressToNode.resolves(node);
             node.discovered.resolves(true);
             taskProtocol.activeTaskExists.resolves();
+            taskProtocol.requestProfile.resolves();
 
             return messageHandler.isBootFileNameSent(packetData)
             .then(function(result) {
                 expect(result).to.equal(true);
+            });
+        });
+
+        it("should not send bootfile name if node is discovered, has active tasks, but no profiles",
+        function() {
+            lookupService.macAddressToNode.resolves(node);
+            node.discovered.resolves(true);
+            taskProtocol.activeTaskExists.resolves();
+            taskProtocol.requestProfile.rejects(new Error(''));
+
+            return messageHandler.isBootFileNameSent(packetData)
+            .then(function(result) {
+                expect(result).to.equal(false);
             });
         });
 


### PR DESCRIPTION
There's many unreasonable get profile retrying iPXE stage when I analysis the master ci log http://rackhdci.lss.emc.com/job/MasterCI/67/artifact/Install-ESXI-6.0/vagrant.log. add pre-check for profiles so that if there's no profile. monorail-undionly.kpxe would be sent to node, and it wouldn't  ipxe boot, go to default bios boot sequence.


@RackHD/corecommitters @iceiilin @yyscamper @leoyjchang @PengTian0 