### PR TITLE
[RAC-5774]add deb build in on-dhcp-proxy's TravisCI .

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
 
 after_success:
  - ./extra/make-testcoveralls.sh
+ - ./extra/make-deb.sh
 
 
 notifications:

--- a/extra/make-deb.sh
+++ b/extra/make-deb.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -ex
+
+# Ensure we're always in the right directory.
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+# Use the TRAVIS_BRANCH var if defined as travis vm
+# doesn't run the git symbolic-ref command.
+if [ -z "$TRAVIS_BRANCH" ]; then
+   BRANCH=$(git symbolic-ref --short -q HEAD)
+else
+   BRANCH=${TRAVIS_BRANCH}
+fi
+
+# this appends a datestring formatting specifically to be increasing
+# based on the last date of the commit in this branch to provide increasing
+# DCH version numbers for building debian packages for bintray.
+GITCOMMITDATE=$(git show -s --pretty="format:%ci")
+DATESTRING=$(date -d "$GITCOMMITDATE" -u +"%Y%m%d%H%M%SZ")
+
+if [ -z "$DEBFULLNAME" ]; then
+        export DEBFULLNAME=`git log -n 1 --pretty=format:%an`
+fi
+
+if [ -z "$DEBEMAIL" ]; then
+        export DEBEMAIL=`git log -n 1 --pretty=format:%ae`
+fi
+
+if [ -z "$DEBBRANCH" ]; then
+        export DEBBRANCH=`echo "${BRANCH}-${DATESTRING}" | sed 's/[\/\_]/-/g'`
+fi
+
+if [ -z "$DEBPKGVER" ]; then
+  export DEBPKGVER=`git log -n 1 --pretty=oneline --abbrev-commit`
+fi
+
+if [ -z "$DCHOPTS" ]; then
+        export DCHOPTS="-l ${DEBBRANCH} -u low ${DEBPKGVER}"
+fi
+
+echo "DEBDIR:       $DEBDIR"
+echo "DEBFULLNAME:  $DEBFULLNAME"
+echo "DEBEMAIL:     $DEBEMAIL"
+echo "DEBBRANCH:    $DEBBRANCH"
+echo "DEBPKGVER:    $DEBPKGVER"
+echo "DCHOPTS:      $DCHOPTS"
+
+
+if [ -d packagebuild ]; then
+  rm -rf packagebuild
+fi
+mkdir packagebuild
+rsync -ar --exclude=packagebuild . packagebuild
+pushd packagebuild
+rm -rf node_modules
+npm install --production
+git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
+dch ${DCHOPTS}
+debuild --no-lintian --no-tgz-check -us -uc
+popd
+if [ ! -d deb ]; then
+  mkdir deb
+fi
+
+cp -a *.deb deb/


### PR DESCRIPTION
## 1 Backgroud
 Some release repos don't have after-merge deb build process in TravisCI. 

At present, on-http, on-imagebuiilder and some other packages has TravisCI deb build process after PR merged, but on-taskgraph didn't have, please make all relates packages have the same process in TravisCI.

## 2 Solution
There's 2 ways:

1. keep deb build in all Travis CI:
    - Pros to keep deb build in Travis CI: can verify the deb build is good during TravisCI PR Gate (which we don't have deb-build-test in Jenkins PR Gate )
    - Cons: make Travis CI PR Gate longer time.

2. remove all deb build for Travis CI
    - Pros/Cons: refer to 1

## 3 Summary
According to Peter's discussion, we decided to keep deb build in all Travis CI. And There are seven repositories that are ought to build debian package in Travis CI. They are on-dhcp, on-http, on-imagebuilder, on-syslog, on-taskgraph, on-tftp and ucs-service.

## 4 Related PR

- [on-http 725](https://github.com/RackHD/on-http/pull/725)
- [on-syslog 44](https://github.com/RackHD/on-syslog/pull/44)
- [on-taskgraph 266](https://github.com/RackHD/on-taskgraph/pull/266)
- [on-tftp 67](https://github.com/RackHD/on-tftp/pull/67) 
- [ucs-service 23](https://github.com/RackHD/ucs-service/pull/23)
