### PR TITLE
Fixing dhcp tftp-server-name option

### DIFF
--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -56,7 +56,7 @@ subnet 10.1.1.0 netmask 255.255.255.0 {
         # Cisco POAP required DHCP options
         option routers 10.1.1.1;
         option domain-name-servers 10.1.1.1;
-        option tftp-server "10.1.1.1";
+        option tftp-server-name "10.1.1.1";
 
         # Cisco POAP only supports TFTP downloads
         option bootfile-name "cisco-poap.py";


### PR DESCRIPTION
tftp-server is not a valid option for isc-dhcp-server. Fixing to tftp-server-name instead