### PR TITLE
update mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "istanbul": "^0.3.5",
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
-    "mocha": "^2.1.0",
+    "mocha": "^4.0.1",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",


### PR DESCRIPTION
Update mocha from 2.1.0 to 4.0.1

**Background**
----
Current mocha 2.1.0 cannot return failure in PR Gate, to fix this, update is needed


@iceiilin @anhou @pengz1 @bbcyyb @PengTian0 
