### PR TITLE
RAC-6393: enable travisci nodejs6/8 gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ node_js:
   - "4"
   - "6"
   - "8"
-matrix:
-  allow_failures:
-   - node_js: "6"
-   - node_js: "8"
 
 addons:
   apt:


### PR DESCRIPTION
Enable travisci nodejs6/8 gate

@anhou @mcgg @pengz1 